### PR TITLE
Update SwerveDrive.java

### DIFF
--- a/src/main/java/frc/robot/SwerveDrive.java
+++ b/src/main/java/frc/robot/SwerveDrive.java
@@ -41,7 +41,7 @@ public class SwerveDrive {
 
     // Subtracts two angles
     public double angleSubtractor (double firstAngle, double secondAngle) {
-        double result = (((firstAngle - secondAngle) + 180)%360) -180;
+        double result = ((((firstAngle - secondAngle) + 180)%360 + 360) % 360) -180;
         return result;
 
     }


### PR DESCRIPTION
might fix taking the long way around when spinning sometimes

In Java, `a % 360` will return a negative value if `a` is negative. 